### PR TITLE
Fix Spelling Mistake in browsing.inipp

### DIFF
--- a/browsing.inipp
+++ b/browsing.inipp
@@ -1,7 +1,7 @@
 [Main]
 browsing={
     CatTypes: {
-        description: "Simple adjustable token alnlyzing tool",
+        description: "Simple adjustable token analyzing tool",
         language: "C++",
         author:"CatCaretaker",
     },


### PR DESCRIPTION
Just noticed a spelling mistake whilst looking at `catcare browse official`